### PR TITLE
FIX: Correct type hinting for Python 3.9 compatibility (#17)

### DIFF
--- a/evalverse/evaluator.py
+++ b/evalverse/evaluator.py
@@ -7,6 +7,7 @@ import os
 import time
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Union, Optional
 
 from evalverse.connector import (
     eq_bench,
@@ -139,7 +140,8 @@ class Evaluator:
 
         return args
 
-    def run(self, model: str = None, benchmark: str | list = None, **kwargs):
+    def run(self, model: Optional[str] = None, benchmark: Optional[Union[str, list]] = None, **kwargs):
+
         # update args
         args = self.get_args()
         args = self.update_args(args, model, benchmark, kwargs)

--- a/evalverse/reporter.py
+++ b/evalverse/reporter.py
@@ -6,6 +6,7 @@ import os
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
+from typing import Union, List
 
 from evalverse.utils import (
     EVALVERSE_DB_PATH,
@@ -130,7 +131,8 @@ class Reporter:
         else:
             pass
 
-    def run(self, model_list: list | str = "all", benchmark_list: list | str = "all", save=False):
+    def run(self, model_list: Union[List, str] = "all", benchmark_list: Union[List, str] = "all", save: bool = False):
+
         if type(model_list) == list:
             for m in model_list:
                 if m in self.model_list:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows _evalverse_ guidelines [link](https://github.com/UpstageAI/evalverse/blob/main/contribution/CONTRIBUTING.md#commit-messages):
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## What does this PR do?
<!-- Please describe the link to a relevant issue and current behavior that you are modifying.-->

- Issue Number: #17 
- Description: This PR addresses issue #17 by updating the `evalverse` project to support Python 3.9 while adhering to PEP 604 convention, which is only supported in Python 3.10 and above. The current implementation may lead to compatibility issues as PEP 604 is not available in Python 3.9. By modifying the project to follow conventions compatible with Python 3.9, we ensure broader compatibility without sacrificing code quality.